### PR TITLE
v1.5.6: enable Recorder statistics and persistent counter states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to HA Daily Counter will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.6] - 2026-08-01
+
+### Fixed
+- Counter sensors now declare the supported `total_increasing` state class through Home Assistant's `SensorStateClass` API and expose the numeric `events` unit, making them eligible for Recorder long-term statistics.
+- The restored counter value is explicitly published when the entity starts, ensuring Recorder receives a state after every Home Assistant restart.
+- Daily-reset listeners are now registered for cleanup when an entity is unloaded, preventing stale callbacks after an integration reload.
+
+### Notes
+- Home Assistant records these sensors in its database by default. Users who exclude the integration or entity in their `recorder` configuration must remove that exclusion to collect history and statistics.
+
 ## [1.5.5] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Auto-reset counters daily at midnight (00:00 local time).  
 - Persistent values across Home Assistant restarts.  
 - Fully manageable via the UI (no YAML required).  
-- Exposed as `sensor` entities with `state_class: total_increasing` and `mdi:counter` icon.  
+- Exposed as `sensor` entities with `state_class: total_increasing`, the `events` unit and `mdi:counter` icon, so Home Assistant Recorder can generate long-term statistics.
 - Includes **reset** and **set** services for manual control.
 - **Multi-language Support**: English, Spanish, French, Portuguese, and German
 

--- a/custom_components/ha_daily_counter/manifest.json
+++ b/custom_components/ha_daily_counter/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Geek-MD/HA_Daily_Counter/issues",
   "requirements": [],
-  "version": "1.5.5"
+  "version": "1.5.6"
 }

--- a/custom_components/ha_daily_counter/sensor.py
+++ b/custom_components/ha_daily_counter/sensor.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
@@ -61,8 +61,11 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
     """Sensor that counts trigger events and resets daily at local midnight."""
 
     _attr_icon = "mdi:counter"
-    _attr_state_class = "total_increasing"
-    _attr_native_unit_of_measurement = None
+    # A numeric unit and a supported state class make the entity eligible for
+    # Recorder long-term statistics. Home Assistant records every state written
+    # by this entity in its database (unless the user explicitly excludes it).
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "events"
     _attr_should_poll = False
 
     def __init__(
@@ -174,16 +177,32 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
 
         # Schedule daily reset
         next_reset = self._get_next_reset_time()
-        self._cancel_reset = async_track_point_in_utc_time(
-            self.hass,
-            self._reset_counter,
-            next_reset,
-        )
+        self.async_on_remove(self._cancel_scheduled_reset)
+        self._schedule_reset(next_reset)
         _LOGGER.debug("Scheduled reset for '%s' at %s", self._name, next_reset)
+
+        # Publish the restored value explicitly. Besides making it immediately
+        # available, this creates a Recorder state after a Home Assistant restart.
+        self.async_write_ha_state()
 
         # Cache this entity for service access
         self.hass.data.setdefault(DOMAIN, {})[self.entity_id] = self
         _LOGGER.debug("Cached entity '%s' for services", self.entity_id)
+
+    def _schedule_reset(self, reset_at: datetime) -> None:
+        """Schedule the next daily reset."""
+        self._cancel_reset = async_track_point_in_utc_time(
+            self.hass,
+            self._reset_counter,
+            reset_at,
+        )
+
+    @callback
+    def _cancel_scheduled_reset(self) -> None:
+        """Cancel the currently scheduled reset when the entity is unloaded."""
+        if self._cancel_reset is not None:
+            self._cancel_reset()
+            self._cancel_reset = None
 
     @callback
     def _handle_trigger_state_change(self, event: Any) -> None:
@@ -246,11 +265,7 @@ class HADailyCounterEntity(SensorEntity, RestoreEntity):
         _LOGGER.info("Counter '%s' reset to 0", self._name)
 
         next_reset = self._get_next_reset_time()
-        self._cancel_reset = async_track_point_in_utc_time(
-            self.hass,
-            self._reset_counter,
-            next_reset,
-        )
+        self._schedule_reset(next_reset)
         _LOGGER.debug("Next reset for '%s' scheduled at %s", self._name, next_reset)
 
     def _get_next_reset_time(self) -> datetime:


### PR DESCRIPTION
### Motivation
- Make counter sensors eligible for Home Assistant Recorder long-term statistics so users can view historical counts. 
- Ensure restored counter values are published at startup so Recorder receives a state after a restart. 
- Prevent stale daily-reset callbacks after integration reload/unload by cleaning up scheduled listeners.

### Description
- Declare the sensor state class using `SensorStateClass.TOTAL_INCREASING` and set a numeric unit `events` in `custom_components/ha_daily_counter/sensor.py` so Recorder can record statistics. 
- Publish the restored value explicitly with `async_write_ha_state()` when the entity is added to Home Assistant to create a Recorder state after restarts. 
- Refactor reset scheduling into `_schedule_reset()` and add `_cancel_scheduled_reset()` plus `async_on_remove(...)` registration to ensure daily-reset listeners are cancelled on unload, and use `_schedule_reset()` when rescheduling. 
- Bump integration `version` to `1.5.6` in `manifest.json` and document the change in `CHANGELOG.md` and `README.md`.

### Testing
- Ran `python -m compileall -q custom_components` and it succeeded. 
- Ran `ruff check .` and it succeeded. 
- Ran `mypy custom_components` and it succeeded. 
- Ran `git diff --check` and workspace checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e39aee9fc8320bcf74974ce51981d)