### PR TITLE
Release v1.5.7 — add switch and finite-state domain monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to HA Daily Counter will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.7] - 2026-08-02
+
+### Added
+- Added `switch` to the entity-domain selector so switch state changes can be monitored directly.
+- Added the other finite-state domains already supported by the smart state selector—`light`, `fan`, `cover`, `lock`, and `alarm_control_panel`—to the entity-domain selector.
+
+### Fixed
+- Lock entities now offer their actual lock states instead of the generic `on` / `off` choices, and the alarm-control-panel list includes its arming, disarming, vacation, and custom-bypass states. Custom states remain available.
+
 ## [1.5.6] - 2026-08-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 - Configure **one or more trigger entities** from multiple domains:
   - **Binary Sensors** (doors, windows, motion detectors)
   - **Sensors** (temperature, humidity, etc.)
+  - **Switches, Lights, and Fans**
+  - **Covers, Locks, and Alarm Control Panels**
   - **Automations** (track automation executions)
   - **Scripts** (monitor script runs)
   - **Input Helpers** (input_boolean, input_number, input_select)
@@ -70,7 +72,7 @@
 2. Fill in the multi-step form:  
    - **Step 1 – Counter Setup**:
      - **Name**: Friendly name of the counter.
-     - **Entity Type**: Select the domain to filter entities (Binary Sensor, Sensor, Automation, Script, or Input Helpers).
+     - **Entity Type**: Select the domain to filter entities (Binary Sensor, Sensor, Switch, Light, Fan, Cover, Lock, Alarm Control Panel, Automation, Script, or Input Helpers).
    - **Step 2 – Trigger Entity**:
      - **Trigger Entity**: Entity that will increment the counter (filtered to the selected type).
    - **Step 3 – Trigger State**:

--- a/custom_components/ha_daily_counter/config_flow.py
+++ b/custom_components/ha_daily_counter/config_flow.py
@@ -28,6 +28,12 @@ LOGIC_OPTIONS = ["AND", "OR"]  # Only AND and OR, OR by default
 DOMAIN_OPTIONS = [
     SelectOptionDict(value="binary_sensor", label="Binary Sensor"),
     SelectOptionDict(value="sensor", label="Sensor"),
+    SelectOptionDict(value="switch", label="Switch"),
+    SelectOptionDict(value="light", label="Light"),
+    SelectOptionDict(value="fan", label="Fan"),
+    SelectOptionDict(value="cover", label="Cover"),
+    SelectOptionDict(value="lock", label="Lock"),
+    SelectOptionDict(value="alarm_control_panel", label="Alarm Control Panel"),
     SelectOptionDict(value="automation", label="Automation"),
     SelectOptionDict(value="script", label="Script"),
     SelectOptionDict(value="input_boolean", label="Input Boolean"),
@@ -55,15 +61,35 @@ def _get_entity_states(hass: HomeAssistant, entity_id: str) -> list[str]:
         "switch",
         "light",
         "fan",
-        "lock",
         "automation",
         "script",
     ):
         return ["on", "off"]
+    if domain == "lock":
+        return [
+            "locked",
+            "unlocked",
+            "locking",
+            "unlocking",
+            "jammed",
+            "open",
+            "opening",
+        ]
     if domain == "cover":
         return ["open", "closed", "opening", "closing"]
     if domain == "alarm_control_panel":
-        return ["disarmed", "armed_home", "armed_away", "armed_night", "pending", "triggered"]
+        return [
+            "disarmed",
+            "armed_home",
+            "armed_away",
+            "armed_night",
+            "armed_vacation",
+            "armed_custom_bypass",
+            "pending",
+            "arming",
+            "disarming",
+            "triggered",
+        ]
     if domain == "input_select" and state_obj:
         return list(state_obj.attributes.get("options", [state_obj.state]))
     if state_obj:

--- a/custom_components/ha_daily_counter/manifest.json
+++ b/custom_components/ha_daily_counter/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Geek-MD/HA_Daily_Counter/issues",
   "requirements": [],
-  "version": "1.5.6"
+  "version": "1.5.7"
 }


### PR DESCRIPTION
### Motivation
- Enable monitoring of `switch` entities and other finite-state domains from the config flow entity selector so counters can track more HA device types.
- Provide accurate, domain-appropriate suggested state choices (e.g., real lock and alarm states) for the smart state selector to improve UX and avoid misleading `on`/`off` suggestions.
- Bump integration version and update documentation and changelog to reflect the new supported domains.

### Description
- Added `switch`, `light`, `fan`, `cover`, `lock`, and `alarm_control_panel` to the domain options shown by the config flow (`custom_components/ha_daily_counter/config_flow.py`).
- Extended `_get_entity_states` in `config_flow.py` to keep `switch`, `light`, and `fan` as `on`/`off`, add explicit `lock` states (`locked`, `unlocked`, `locking`, `unlocking`, `jammed`, `open`, `opening`), and expand `alarm_control_panel` states (arming/ disarming/ vacation/ custom bypass, etc.).
- Updated `manifest.json` to `"version": "1.5.7"` and refreshed `README.md` and `CHANGELOG.md` to document the new domains and state behavior.

### Testing
- Ran `git diff --check` with no issues reported, and validated the working tree after the changes.
- Ran static checks: `ruff check custom_components/ha_daily_counter`, which passed with no issues.
- Ran type checks: `mypy custom_components/ha_daily_counter`, which passed.
- Verified byte-compile with `python -m compileall -q custom_components/ha_daily_counter` and validated `manifest.json` with `python -m json.tool`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e89200bf0832086c0ff7984c0afbb)